### PR TITLE
Build and Upload PAM OAuth RPMs (Inf-794)

### DIFF
--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -1,0 +1,22 @@
+name: Build RPMS on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  Build-RPMS:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build RPMS 
+      run: |
+          cd ./packaging/rpm
+          docker build -t pamoauth2device-rpm-build .
+          docker run --rm -u root -v ${{github.workspace}}:/data pamoauth2device-rpm-build cp -r rpmbuild/RPMS /data
+          
+    - name: Upload RPMS
+      uses: actions/upload-artifact@v3
+      with:
+        name: PAM OAuth2 RPMS
+        path: ${{github.workspace}}/RPMS

--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -14,15 +14,15 @@ jobs:
       run: |
         mkdir -p ${{github.workspace}}/build_output
         sudo chown 1000:1000 ${{github.workspace}}/build_output
-        
+
     - name: Build RPMS 
       run: |
           cd ./packaging/rpm
           docker build -t pamoauth2device-rpm-build .
-          docker run --rm -u root -v ${{github.workspace}}:/data pamoauth2device-rpm-build cp -r rpmbuild/RPMS /data
+          docker run --rm -u 1000:1000 --user builder -v ${{github.workspace}}/build_output:/data pamoauth2device-rpm-build:latest cp -r rpmbuild/RPMS /data
           
     - name: Upload RPMS
       uses: actions/upload-artifact@v3
       with:
         name: PAM OAuth2 RPMS
-        path: ${{github.workspace}}/RPMS
+        path: build_output/RPMS

--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -9,6 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: Set up build directory
+      run: |
+        mkdir -p ${{github.workspace}}/build_output
+        sudo chown 1000:1000 ${{github.workspace}}/build_output
+        
     - name: Build RPMS 
       run: |
           cd ./packaging/rpm

--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
           cd ./packaging/rpm
           docker build -t pamoauth2device-rpm-build .
-          docker run --rm --user builder -v ${{github.workspace}}/build_output:/data pamoauth2device-rpm-build:latest cp -r rpmbuild/RPMS /data
+          docker run --rm -v ${{github.workspace}}/build_output:/data pamoauth2device-rpm-build:latest cp -r rpmbuild/RPMS /data
           
     - name: Upload RPMS
       uses: actions/upload-artifact@v3

--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
           cd ./packaging/rpm
           docker build -t pamoauth2device-rpm-build .
-          docker run --rm -u 1000:1000 --user builder -v ${{github.workspace}}/build_output:/data pamoauth2device-rpm-build:latest cp -r rpmbuild/RPMS /data
+          docker run --rm --user builder -v ${{github.workspace}}/build_output:/data pamoauth2device-rpm-build:latest cp -r rpmbuild/RPMS /data
           
     - name: Upload RPMS
       uses: actions/upload-artifact@v3

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y \
  && yum clean all
 
 RUN groupadd builder \
- && useradd --create-home --gid builder builder
+ && useradd --create-home -u 1000 -g 1000 builder
 
 USER builder
 


### PR DESCRIPTION
The uploads can be found at the bottom of the portion of the Actions summary page. The action checks out the code and from the rpm directory builds the container pamoauth2device-rpm-build. The docker run command creates a volume that maps /data inside the container to the .workspace variable which is the file path of the root directory of the current repo on the github actions runner. There was a permission issue between the user of the container and the github actions user where github actions user could not copy anything from inside the container. Setting the container user as root solved the problem but that may not be the appropriate work around. The upload artifact action pulls the build rpms from the .workspace/RPMS path.