### PR TITLE
Be more concrete in when the user should hit enter

### DIFF
--- a/src/pam_oauth2_device.cpp
+++ b/src/pam_oauth2_device.cpp
@@ -162,9 +162,9 @@ std::string DeviceAuthResponse::get_prompt(const int qr_ecc = 0)
                << std::endl
                << getQr((complete_url ? verification_uri_complete : verification_uri).c_str(), qr_ecc)
                << std::endl
-               << "Hit enter when you authenticate\n";
+               << "Hit enter when the website tells you to return to your device\n";
     } else {
-        prompt << "Hit enter when you authenticate\n";
+        prompt << "Hit enter when the website tells you to return to your device\n";
     }
     return prompt.str();
 }


### PR DESCRIPTION
The CILogon website says "Please return to your device for further instructions." after authenticating which is confusing if the user is visiting the website from the same computer they are trying to log in from. Since we can't change the website, tell the user what message to expect instead.

(Copied from https://github.com/bbockelm/pam_oauth2_device/pull/1)