### PR TITLE
Fix build and upload of RPM to release tag (INF-794)

### DIFF
--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Get git tag
+      id: get-git-tag
+      run: |
+        echo "tag_name=${GITHUB_REF##refs/tags/}" >> $GITHUB_OUTPUT
+
     - name: Set up build directory
       run: |
         mkdir -p ${{github.workspace}}/build_output
@@ -25,9 +30,12 @@ jobs:
     - name: Build RPMs
       env:
         IMAGE_BASE: ${{ matrix.os_base }}
+        GIT_TAG: ${{ steps.get-git-tag.outputs.tag_name }}
       run: |
+          URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/archive/${GIT_TAG}.tar.gz
           cd ./packaging/rpm
           docker build --build-arg IMAGE_BASE=$IMAGE_BASE \
+                       --build-arg TARBALL_URL=$URL \
                        -t pamoauth2device-rpm-build .
           docker run --rm \
                      -v ${{github.workspace}}/build_output:/data \

--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -40,10 +40,13 @@ jobs:
           docker run --rm \
                      -v ${{github.workspace}}/build_output:/data \
                      pamoauth2device-rpm-build:latest \
-                     cp -r rpmbuild/RPMS /data
+                     cp -r rpmbuild/RPMS rpmbuild/SRPMS /data
 
-    - name: Upload RPMS
-      uses: actions/upload-artifact@v3
+    - name: Upload Release Artifacts
+      uses: softprops/action-gh-release@v1
       with:
-        name: PAM OAuth2 RPMS
-        path: build_output/RPMS
+        files: |
+          ${{ github.workspace}}/build_output/RPMS/x86_64/*
+          ${{ github.workspace}}/build_output/SRPMS/*
+        tag_name: ${{ steps.get-git-tag.outputs.tag_name }}
+

--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -6,6 +6,12 @@ on:
 
 jobs:
   Build-RPMS:
+    strategy:
+      fail-fast: false
+      matrix:
+        os_base:
+          - "docker.io/centos:centos7"
+          - "quay.io/almalinux/almalinux:8"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -16,9 +22,12 @@ jobs:
         sudo chown 1000:1000 ${{github.workspace}}/build_output
 
     - name: Build RPMS 
+      env:
+        IMAGE_BASE: ${{ matrix.os_base }}
       run: |
           cd ./packaging/rpm
-          docker build -t pamoauth2device-rpm-build .
+          docker build --build-arg IMAGE_BASE=$IMAGE_BASE \
+                       -t pamoauth2device-rpm-build .
           docker run --rm -v ${{github.workspace}}/build_output:/data pamoauth2device-rpm-build:latest cp -r rpmbuild/RPMS /data
           
     - name: Upload RPMS

--- a/.github/workflows/pamoauthrpmbuild.yml
+++ b/.github/workflows/pamoauthrpmbuild.yml
@@ -1,3 +1,4 @@
+---
 name: Build RPMS on release
 
 on:
@@ -21,15 +22,18 @@ jobs:
         mkdir -p ${{github.workspace}}/build_output
         sudo chown 1000:1000 ${{github.workspace}}/build_output
 
-    - name: Build RPMS 
+    - name: Build RPMs
       env:
         IMAGE_BASE: ${{ matrix.os_base }}
       run: |
           cd ./packaging/rpm
           docker build --build-arg IMAGE_BASE=$IMAGE_BASE \
                        -t pamoauth2device-rpm-build .
-          docker run --rm -v ${{github.workspace}}/build_output:/data pamoauth2device-rpm-build:latest cp -r rpmbuild/RPMS /data
-          
+          docker run --rm \
+                     -v ${{github.workspace}}/build_output:/data \
+                     pamoauth2device-rpm-build:latest \
+                     cp -r rpmbuild/RPMS /data
+
     - name: Upload RPMS
       uses: actions/upload-artifact@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=-Wall -fPIC -std=c++11
+CXXFLAGS=-Wall -fPIC -std=c++11 -g
 
 LDLIBS=-lpam -lcurl -lldap -llber
 

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_BASE=quay.io/almalinux/almalinux:8
 FROM $IMAGE_BASE
 
 # "ARG IMAGE_BASE" needs to be here again because the previous instance has gone out of scope.
-ARG IMAGE_BASE=quay.io/centos/centos:stream8
+ARG IMAGE_BASE=quay.io/almalinux/almalinux:8
 ARG TARBALL_URL=https://github.com/CHTC/pam_oauth2_device/archive/v0.1.3.chtc.tar.gz
 
 RUN yum install -y \

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -1,4 +1,10 @@
-FROM centos:7
+# Default to EL8 builds
+ARG IMAGE_BASE=quay.io/almalinux/almalinux:8
+
+FROM $IMAGE_BASE
+
+# "ARG IMAGE_BASE" needs to be here again because the previous instance has gone out of scope.
+ARG IMAGE_BASE=quay.io/centos/centos:stream8
 
 RUN yum install -y \
     gcc \

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -5,6 +5,7 @@ FROM $IMAGE_BASE
 
 # "ARG IMAGE_BASE" needs to be here again because the previous instance has gone out of scope.
 ARG IMAGE_BASE=quay.io/centos/centos:stream8
+ARG TARBALL_URL=https://github.com/CHTC/pam_oauth2_device/archive/v0.1.3.chtc.tar.gz
 
 RUN yum install -y \
     gcc \
@@ -21,14 +22,11 @@ RUN groupadd builder \
 
 USER builder
 
-# This version must be identical to the version in pamoauth2device.spec
-ENV PACKAGE_VERSION=0.1.3.chtc
-
 WORKDIR /home/builder
 
 RUN mkdir -p rpmbuild/SOURCES \
  && cd rpmbuild/SOURCES \
- && curl -L -O https://github.com/stfc/pam_oauth2_device/archive/v${PACKAGE_VERSION}.tar.gz
+ && curl -L -O $TARBALL_URL
 
 COPY pamoauth2device.spec .
 


### PR DESCRIPTION
This also contains #3 so that should probably be reviewed first.

It also adds EL8 builds. Works here https://github.com/brianhlin/pam_oauth2_device/releases/tag/v0.1.3.chtc

@jtakaki-matc this is actually what I had in mind originally: I wanted the RPM products uploaded to the actual GitHub release, not the GitHub aciton workflow.

Note that I had to update the GitHub repo configuration to allow reading + writing via workflows